### PR TITLE
Update android 12 / 13

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -6,7 +6,7 @@ repositories{
 }
 
 dependencies {
-   compile(name:'jp2-android-1.0', ext:'aar')
+   implementation(name:'jp2-android-1.0', ext:'aar')
 }
 
 android {


### PR DESCRIPTION
compile is deprecated and wille give errors when building an app with targetsdk 31 or 32 . Changed to implementation